### PR TITLE
Add configurable file size for persistent stores & fix flush count double-counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ use feoxdb::FeoxStore;
 fn main() -> feoxdb::Result<()> {
     let store = FeoxStore::builder()
         .device_path("/data/myapp.feox")
+        .file_size(10 * 1024 * 1024 * 1024)  // 10GB initial file size
         .max_memory(2_000_000_000)  // 2GB limit
         .enable_caching(true)        // Enable CLOCK cache
         .hash_bits(20)               // 1M hash buckets

--- a/src/core/store/builder.rs
+++ b/src/core/store/builder.rs
@@ -14,6 +14,7 @@ pub struct StoreConfig {
     pub memory_only: bool,
     pub enable_caching: bool,
     pub device_path: Option<String>,
+    pub file_size: Option<u64>,
     pub max_memory: Option<usize>,
     pub enable_ttl: bool,
     pub ttl_config: Option<TtlConfig>,
@@ -40,6 +41,7 @@ pub struct StoreConfig {
 pub struct StoreBuilder {
     hash_bits: u32,
     device_path: Option<String>,
+    file_size: Option<u64>,
     max_memory: Option<usize>,
     enable_caching: Option<bool>,
     enable_ttl: bool,
@@ -51,6 +53,7 @@ impl StoreBuilder {
         Self {
             hash_bits: DEFAULT_HASH_BITS,
             device_path: None,
+            file_size: None,
             max_memory: Some(DEFAULT_MAX_MEMORY),
             enable_caching: None, // Disable caching for memory-only mode
             enable_ttl: false,
@@ -64,6 +67,30 @@ impl StoreBuilder {
     /// If not set, the store operates in memory-only mode.
     pub fn device_path(mut self, path: impl Into<String>) -> Self {
         self.device_path = Some(path.into());
+        self
+    }
+
+    /// Set the initial file size for new persistent stores (in bytes).
+    ///
+    /// When creating a new persistent store file, it will be pre-allocated
+    /// to this size for better performance. If not set, defaults to 1GB.
+    /// This option is ignored for existing files.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use feoxdb::FeoxStore;
+    ///
+    /// # fn main() -> feoxdb::Result<()> {
+    /// let store = FeoxStore::builder()
+    ///     .device_path("/path/to/data.feox")
+    ///     .file_size(10 * 1024 * 1024 * 1024)  // 10GB
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn file_size(mut self, size: u64) -> Self {
+        self.file_size = Some(size);
         self
     }
 
@@ -165,6 +192,7 @@ impl StoreBuilder {
             memory_only,
             enable_caching,
             device_path: self.device_path,
+            file_size: self.file_size,
             max_memory: self.max_memory,
             enable_ttl: self.enable_ttl,
             ttl_config: self.ttl_config,

--- a/src/core/store/init.rs
+++ b/src/core/store/init.rs
@@ -21,6 +21,7 @@ impl FeoxStore {
             memory_only,
             enable_caching: !memory_only, // Disable caching for memory-only mode
             device_path,
+            file_size: None,
             max_memory: Some(DEFAULT_MAX_MEMORY),
             enable_ttl: false,
             ttl_config: None,
@@ -58,7 +59,7 @@ impl FeoxStore {
         };
 
         if !config.memory_only {
-            store.open_device(&config.device_path)?;
+            store.open_device(&config.device_path, config.file_size)?;
             store.load_indexes()?;
 
             // Initialize write buffer for persistent mode
@@ -111,7 +112,7 @@ impl FeoxStore {
         };
 
         if !config.memory_only {
-            store.open_device(&config.device_path)?;
+            store.open_device(&config.device_path, config.file_size)?;
             store.load_indexes()?;
 
             // Initialize write buffer for persistent mode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,11 +95,13 @@
 //! ```
 //!
 //! ### Using the Builder Pattern
-//! ```rust
+//! ```no_run
 //! use feoxdb::FeoxStore;
 //!
 //! # fn main() -> feoxdb::Result<()> {
 //! let store = FeoxStore::builder()
+//!     .device_path("/path/to/data.feox")
+//!     .file_size(5 * 1024 * 1024 * 1024)  // 5GB initial file size (default: 1GB)
 //!     .max_memory(1024 * 1024 * 1024)  // 1GB limit
 //!     .hash_bits(20)  // 1M hash buckets
 //!     .enable_ttl(true)  // Enable TTL support (default: false)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -148,7 +148,6 @@ impl Statistics {
 
     pub fn record_write_flushed(&self, count: u64) {
         self.writes_flushed.fetch_add(count, Ordering::Relaxed);
-        self.flush_count.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn record_write_failed(&self) {


### PR DESCRIPTION
## Summary:
This PR adds the ability to specify custom file sizes when creating new persistent stores and fixes a statistics bug where flush counts were being incremented twice.

## Changes:
  - Added file_size() method to StoreBuilder to configure initial file size (defaults to 1GB)
  - Fixed double-counting of flush_count in statistics (was incrementing in both record_write_flushed and write_buffer_worker)
  - Updated documentation with examples showing pre-allocated files and custom file sizes
  - Minor improvements to deterministic_test example