### PR TITLE
Migrated from DashMap to SCC HashMap and introduced zero-copy insert path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crossbeam-utils = "0.8"
 crossbeam-channel = "0.5"
 crossbeam-skiplist = "0.1.3"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
-dashmap = "6.1"
+scc = "2.1"
 
 # Memory management
 bytes = "1.5"

--- a/NOTICE
+++ b/NOTICE
@@ -8,9 +8,9 @@ The FeOxDB Project (https://github.com/mehrantsi/feoxdb).
 
 This software includes the following third-party components:
 
-- DashMap: Licensed under MIT License
-  Copyright (c) 2019 Acrimon
-  https://github.com/xacrimon/dashmap
+- SCC (Scalable Concurrent Containers): Licensed under Apache-2.0
+  Copyright (c) 2023 wvwwvwwv
+  https://github.com/wvwwvwwv/scalable-concurrent-containers
 
 - SkipList: Licensed under MIT License
   Copyright (c) 2016 The Crossbeam Project

--- a/examples/deterministic_test.rs
+++ b/examples/deterministic_test.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use feoxdb::error::Result;
 use feoxdb::FeoxStore;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -344,10 +345,10 @@ fn main() -> Result<()> {
     let phase_start = Instant::now();
     for i in 0..num_keys {
         let key = generate_key(i);
-        let value = generate_value(value_size);
+        let value = Bytes::from(generate_value(value_size));
 
         let op_start = Instant::now();
-        let success = store.insert(&key, &value).is_ok();
+        let success = store.insert_bytes(&key, value).is_ok();
         let latency_ns = op_start.elapsed().as_nanos() as u64;
 
         insert_stats.record(latency_ns, success);

--- a/src/core/store/init.rs
+++ b/src/core/store/init.rs
@@ -1,6 +1,6 @@
 use crossbeam_skiplist::SkipMap;
-use dashmap::DashMap;
 use parking_lot::RwLock;
+use scc::HashMap;
 use std::sync::Arc;
 
 use crate::constants::*;
@@ -26,7 +26,7 @@ impl FeoxStore {
             enable_ttl: false,
             ttl_config: None,
         };
-        let hash_table = DashMap::with_capacity(1 << config.hash_bits);
+        let hash_table = HashMap::with_capacity(1 << config.hash_bits);
 
         let free_space = Arc::new(RwLock::new(FreeSpaceManager::new()));
         let metadata = Arc::new(RwLock::new(Metadata::new()));
@@ -79,7 +79,7 @@ impl FeoxStore {
     /// Create a new FeoxStore with custom configuration
     pub fn with_config(config: StoreConfig) -> Result<Self> {
         // Initialize hash table with configured capacity
-        let hash_table = DashMap::with_capacity(1 << config.hash_bits);
+        let hash_table = HashMap::with_capacity(1 << config.hash_bits);
 
         let free_space = Arc::new(RwLock::new(FreeSpaceManager::new()));
         let metadata = Arc::new(RwLock::new(Metadata::new()));

--- a/src/core/store/json_patch.rs
+++ b/src/core/store/json_patch.rs
@@ -76,7 +76,10 @@ impl FeoxStore {
 
         // Get the value and release the lock immediately
         let current_value = {
-            let record = self.hash_table.get(key).ok_or(FeoxError::KeyNotFound)?;
+            let record = self
+                .hash_table
+                .read(key, |_, v| v.clone())
+                .ok_or(FeoxError::KeyNotFound)?;
 
             if timestamp < record.timestamp {
                 return Err(FeoxError::OlderTimestamp);

--- a/src/core/store/mod.rs
+++ b/src/core/store/mod.rs
@@ -1,6 +1,6 @@
 use crossbeam_skiplist::SkipMap;
-use dashmap::DashMap;
 use parking_lot::RwLock;
+use scc::HashMap;
 use std::sync::Arc;
 
 use crate::core::record::Record;
@@ -35,8 +35,8 @@ pub mod ttl;
 ///
 /// All methods are thread-safe and can be called concurrently from multiple threads.
 pub struct FeoxStore {
-    // Main hash table with lock-free operations
-    pub(super) hash_table: DashMap<Vec<u8>, Arc<Record>>,
+    // Main hash table with fine-grained locking
+    pub(super) hash_table: HashMap<Vec<u8>, Arc<Record>>,
 
     // Lock-free skip list for ordered access
     pub(super) tree: Arc<SkipMap<Vec<u8>, Arc<Record>>>,
@@ -98,7 +98,7 @@ impl FeoxStore {
 
     /// Check if a key exists
     pub fn contains_key(&self, key: &[u8]) -> bool {
-        self.hash_table.contains_key(key)
+        self.hash_table.contains(key)
     }
 
     /// Get the number of records in the store

--- a/src/core/store/operations.rs
+++ b/src/core/store/operations.rs
@@ -17,8 +17,8 @@ impl FeoxStore {
     ///
     /// # Arguments
     ///
-    /// * `key` - The key to insert (max 65KB)
-    /// * `value` - The value to store (max 4GB)
+    /// * `key` - The key to insert
+    /// * `value` - The value to store
     /// * `timestamp` - Optional timestamp for conflict resolution. If `None`, uses current time.
     ///
     /// # Returns
@@ -58,8 +58,8 @@ impl FeoxStore {
     ///
     /// # Arguments
     ///
-    /// * `key` - The key to insert (max 65KB)
-    /// * `value` - The value to store (max 4GB)
+    /// * `key` - The key to insert
+    /// * `value` - The value to store
     /// * `timestamp` - Optional timestamp for conflict resolution. If `None`, uses current time.
     ///
     /// # Errors
@@ -72,6 +72,75 @@ impl FeoxStore {
         timestamp: Option<u64>,
     ) -> Result<()> {
         self.insert_with_timestamp_and_ttl_internal(key, value, timestamp, 0)
+    }
+
+    /// Insert or update a key-value pair using zero-copy Bytes.
+    ///
+    /// This method avoids copying the value data by directly using the Bytes type,
+    /// which provides reference-counted zero-copy semantics. Useful when inserting
+    /// data that was already read from network or disk as Bytes.
+    ///
+    /// If the key already exists with a TTL, the TTL is removed (key becomes permanent).
+    /// To preserve or set TTL, use `insert_bytes_with_ttl()` instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to store as Bytes
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if successful.
+    ///
+    /// # Errors
+    ///
+    /// * `InvalidKey` - Key is empty or too large
+    /// * `InvalidValue` - Value is too large
+    /// * `OlderTimestamp` - Timestamp is not newer than existing record
+    /// * `OutOfMemory` - Memory limit exceeded
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use feoxdb::FeoxStore;
+    /// # use bytes::Bytes;
+    /// # fn main() -> feoxdb::Result<()> {
+    /// # let store = FeoxStore::new(None)?;
+    /// let data = Bytes::from_static(b"{\"name\":\"Mehran\"}");
+    /// store.insert_bytes(b"user:123", data)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// * Memory mode: ~600ns (avoids value copy)
+    /// * Persistent mode: ~800ns (buffered write, avoids value copy)
+    pub fn insert_bytes(&self, key: &[u8], value: Bytes) -> Result<()> {
+        self.insert_bytes_with_timestamp(key, value, None)
+    }
+
+    /// Insert or update a key-value pair using zero-copy Bytes with explicit timestamp.
+    ///
+    /// This is the advanced version that allows manual timestamp control for
+    /// conflict resolution. Most users should use `insert_bytes()` instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to store as Bytes
+    /// * `timestamp` - Optional timestamp for conflict resolution. If `None`, uses current time.
+    ///
+    /// # Errors
+    ///
+    /// * `OlderTimestamp` - Timestamp is not newer than existing record
+    pub fn insert_bytes_with_timestamp(
+        &self,
+        key: &[u8],
+        value: Bytes,
+        timestamp: Option<u64>,
+    ) -> Result<()> {
+        self.insert_bytes_with_timestamp_and_ttl_internal(key, value, timestamp, 0)
     }
 
     pub(super) fn insert_with_timestamp_and_ttl_internal(
@@ -144,6 +213,111 @@ impl FeoxStore {
                 if let Err(_e) = wb.add_write(Operation::Insert, record, 0) {
                     // Don't fail the insert - data is still in memory
                     // Return code already indicates success since data is in memory
+                }
+            }
+
+            // Check memory pressure and trigger cache eviction if needed
+            if self.enable_caching {
+                if let Some(ref cache) = self.cache {
+                    let stats = cache.stats();
+                    if stats.memory_usage > stats.high_watermark {
+                        cache.evict_entries();
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Internal method to insert a Bytes value with timestamp and TTL (zero-copy)
+    pub(super) fn insert_bytes_with_timestamp_and_ttl_internal(
+        &self,
+        key: &[u8],
+        value: Bytes,
+        timestamp: Option<u64>,
+        ttl_seconds: u64,
+    ) -> Result<()> {
+        let start = std::time::Instant::now();
+        // Get timestamp before any operations
+        let timestamp = match timestamp {
+            Some(0) | None => self.get_timestamp(),
+            Some(ts) => ts,
+        };
+
+        self.validate_key(key)?;
+        let value_len = value.len();
+        if value_len == 0 || value_len > MAX_VALUE_SIZE {
+            return Err(FeoxError::InvalidValueSize);
+        }
+
+        // Check for existing record
+        let existing_record = self.hash_table.read(key, |_, v| v.clone());
+        if let Some(existing_record) = existing_record {
+            let existing_ts = existing_record.timestamp;
+
+            if timestamp < existing_ts {
+                return Err(FeoxError::OlderTimestamp);
+            }
+
+            // Calculate TTL expiry
+            let ttl_expiry = if ttl_seconds > 0 && self.enable_ttl {
+                timestamp + (ttl_seconds * 1_000_000_000)
+            } else {
+                0
+            };
+
+            // Update existing record using the Bytes version
+            return self.update_record_with_ttl_bytes(
+                &existing_record,
+                value,
+                timestamp,
+                ttl_expiry,
+            );
+        }
+
+        // This point is only reached for new inserts (not updates)
+        let new_size = self.calculate_record_size(key.len(), value_len);
+        if !self.check_memory_limit(new_size) {
+            return Err(FeoxError::OutOfMemory);
+        }
+
+        // Create new record with Bytes value
+        let record = if ttl_seconds > 0 && self.enable_ttl {
+            let ttl_expiry = timestamp + (ttl_seconds * 1_000_000_000);
+            self.stats.keys_with_ttl.fetch_add(1, Ordering::Relaxed);
+            Arc::new(Record::new_from_bytes_with_ttl(
+                key.to_vec(),
+                value,
+                timestamp,
+                ttl_expiry,
+            ))
+        } else {
+            Arc::new(Record::new_from_bytes(key.to_vec(), value, timestamp))
+        };
+
+        let key_vec = record.key.clone();
+
+        // Insert into hash table
+        self.hash_table.upsert(key_vec.clone(), Arc::clone(&record));
+
+        // Insert into skip list for ordered access
+        self.tree.insert(key_vec, Arc::clone(&record));
+
+        // Update statistics
+        self.stats.record_count.fetch_add(1, Ordering::AcqRel);
+        self.stats
+            .memory_usage
+            .fetch_add(new_size, Ordering::AcqRel);
+        self.stats
+            .record_insert(start.elapsed().as_nanos() as u64, false);
+
+        // Only do persistence and cache checks if not in memory-only mode
+        if !self.memory_only {
+            // Queue for persistence if write buffer exists
+            if let Some(ref wb) = self.write_buffer {
+                if let Err(_e) = wb.add_write(Operation::Insert, record, 0) {
+                    // Don't fail the insert - data is still in memory
                 }
             }
 

--- a/src/core/store/operations.rs
+++ b/src/core/store/operations.rs
@@ -206,23 +206,13 @@ impl FeoxStore {
         self.stats
             .record_insert(start.elapsed().as_nanos() as u64, is_update);
 
-        // Only do persistence and cache checks if not in memory-only mode
+        // Only do persistence if not in memory-only mode
         if !self.memory_only {
             // Queue for persistence if write buffer exists
             if let Some(ref wb) = self.write_buffer {
                 if let Err(_e) = wb.add_write(Operation::Insert, record, 0) {
                     // Don't fail the insert - data is still in memory
                     // Return code already indicates success since data is in memory
-                }
-            }
-
-            // Check memory pressure and trigger cache eviction if needed
-            if self.enable_caching {
-                if let Some(ref cache) = self.cache {
-                    let stats = cache.stats();
-                    if stats.memory_usage > stats.high_watermark {
-                        cache.evict_entries();
-                    }
                 }
             }
         }
@@ -312,22 +302,12 @@ impl FeoxStore {
         self.stats
             .record_insert(start.elapsed().as_nanos() as u64, false);
 
-        // Only do persistence and cache checks if not in memory-only mode
+        // Only do persistence if not in memory-only mode
         if !self.memory_only {
             // Queue for persistence if write buffer exists
             if let Some(ref wb) = self.write_buffer {
                 if let Err(_e) = wb.add_write(Operation::Insert, record, 0) {
                     // Don't fail the insert - data is still in memory
-                }
-            }
-
-            // Check memory pressure and trigger cache eviction if needed
-            if self.enable_caching {
-                if let Some(ref cache) = self.cache {
-                    let stats = cache.stats();
-                    if stats.memory_usage > stats.high_watermark {
-                        cache.evict_entries();
-                    }
                 }
             }
         }

--- a/src/core/store/recovery.rs
+++ b/src/core/store/recovery.rs
@@ -120,7 +120,7 @@ impl FeoxStore {
 
             let record_arc = Arc::new(record);
             let key_len = key.len();
-            self.hash_table.insert(key.clone(), Arc::clone(&record_arc));
+            self.hash_table.upsert(key.clone(), Arc::clone(&record_arc));
             self.tree.insert(key, Arc::clone(&record_arc));
 
             self.stats.record_count.fetch_add(1, Ordering::AcqRel);

--- a/src/core/store/ttl.rs
+++ b/src/core/store/ttl.rs
@@ -111,7 +111,10 @@ impl FeoxStore {
         }
         self.validate_key(key)?;
 
-        let record = self.hash_table.get(key).ok_or(FeoxError::KeyNotFound)?;
+        let record = self
+            .hash_table
+            .read(key, |_, v| v.clone())
+            .ok_or(FeoxError::KeyNotFound)?;
         let ttl_expiry = record.ttl_expiry.load(Ordering::Acquire);
 
         if ttl_expiry == 0 {
@@ -160,7 +163,10 @@ impl FeoxStore {
         }
         self.validate_key(key)?;
 
-        let record = self.hash_table.get(key).ok_or(FeoxError::KeyNotFound)?;
+        let record = self
+            .hash_table
+            .read(key, |_, v| v.clone())
+            .ok_or(FeoxError::KeyNotFound)?;
 
         let new_expiry = if ttl_seconds > 0 {
             self.get_timestamp() + (ttl_seconds * 1_000_000_000)

--- a/src/core/store/ttl.rs
+++ b/src/core/store/ttl.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -12,8 +13,8 @@ impl FeoxStore {
     ///
     /// # Arguments
     ///
-    /// * `key` - The key to insert (max 65KB)
-    /// * `value` - The value to store (max 4GB)
+    /// * `key` - The key to insert
+    /// * `value` - The value to store
     /// * `ttl_seconds` - Time-to-live in seconds
     ///
     /// # Returns
@@ -47,8 +48,8 @@ impl FeoxStore {
     ///
     /// # Arguments
     ///
-    /// * `key` - The key to insert (max 65KB)
-    /// * `value` - The value to store (max 4GB)
+    /// * `key` - The key to insert
+    /// * `value` - The value to store
     /// * `ttl_seconds` - Time-to-live in seconds
     /// * `timestamp` - Optional timestamp for conflict resolution. If `None`, uses current time.
     ///
@@ -78,6 +79,71 @@ impl FeoxStore {
         };
 
         self.insert_with_timestamp_and_ttl_internal(key, value, Some(timestamp), ttl_expiry)
+    }
+
+    /// Insert or update a key-value pair with TTL using zero-copy Bytes.
+    ///
+    /// This method avoids copying the value data by directly using the Bytes type,
+    /// which provides reference-counted zero-copy semantics.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to store as Bytes
+    /// * `ttl_seconds` - Time-to-live in seconds
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if successful.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use feoxdb::FeoxStore;
+    /// # use bytes::Bytes;
+    /// # fn main() -> feoxdb::Result<()> {
+    /// # let store = FeoxStore::builder().enable_ttl(true).build()?;
+    /// let data = Bytes::from_static(b"session_data");
+    /// // Key expires after 60 seconds
+    /// store.insert_bytes_with_ttl(b"session:123", data, 60)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// * Memory mode: ~800ns (avoids value copy)
+    /// * Persistent mode: ~1µs (buffered write, avoids value copy)
+    pub fn insert_bytes_with_ttl(&self, key: &[u8], value: Bytes, ttl_seconds: u64) -> Result<()> {
+        if !self.enable_ttl {
+            return Err(FeoxError::TtlNotEnabled);
+        }
+        self.insert_bytes_with_ttl_and_timestamp(key, value, ttl_seconds, None)
+    }
+
+    /// Insert or update a key-value pair with TTL and explicit timestamp using zero-copy Bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert
+    /// * `value` - The value to store as Bytes
+    /// * `ttl_seconds` - Time-to-live in seconds
+    /// * `timestamp` - Optional timestamp for conflict resolution. If `None`, uses current time.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if successful.
+    pub fn insert_bytes_with_ttl_and_timestamp(
+        &self,
+        key: &[u8],
+        value: Bytes,
+        ttl_seconds: u64,
+        timestamp: Option<u64>,
+    ) -> Result<()> {
+        if !self.enable_ttl {
+            return Err(FeoxError::TtlNotEnabled);
+        }
+        self.insert_bytes_with_timestamp_and_ttl_internal(key, value, timestamp, ttl_seconds)
     }
 
     /// Get the remaining TTL (Time-To-Live) for a key in seconds.

--- a/src/core/ttl_sweep.rs
+++ b/src/core/ttl_sweep.rs
@@ -280,25 +280,23 @@ fn sample_and_expire_batch(store: &Arc<FeoxStore>, config: &TtlConfig) -> (u64, 
 
 /// Get a random entry with TTL using sampling
 fn get_random_ttl_entry(
-    hash_table: &dashmap::DashMap<Vec<u8>, Arc<crate::core::record::Record>>,
+    hash_table: &scc::HashMap<Vec<u8>, Arc<crate::core::record::Record>>,
     rng: &mut ThreadRng,
 ) -> Option<(Vec<u8>, Arc<crate::core::record::Record>)> {
     // Sample up to 100 entries and pick one with TTL
     let mut candidates = Vec::new();
     let mut count = 0;
 
-    for entry in hash_table.iter() {
-        if entry.value().ttl_expiry.load(Ordering::Relaxed) > 0 {
-            candidates.push((entry.key().clone(), entry.value().clone()));
-            if candidates.len() >= 10 {
-                break; // Limit candidates to avoid too much memory
-            }
+    hash_table.scan(|key: &Vec<u8>, value: &Arc<crate::core::record::Record>| {
+        if count >= 100 {
+            return; // Stop iteration
         }
         count += 1;
-        if count >= 100 {
-            break; // Limit total iterations
+
+        if value.ttl_expiry.load(Ordering::Relaxed) > 0 {
+            candidates.push((key.clone(), value.clone()));
         }
-    }
+    });
 
     if candidates.is_empty() {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! ## Features
 //!
-//! - **Ultra-Low Latency**: <200ns GET operations, <600ns INSERT operations
-//! - **Lock-Free Operations**: Uses DashMap and SkipList for concurrent access
+//! - **Ultra-Low Latency**: <200ns GET operations, <700ns INSERT operations
+//! - **Lock-Free Operations**: Uses SCC HashMap and SkipList for concurrent access
 //! - **io_uring Support** (Linux): Kernel-bypass I/O for maximum throughput with minimal syscalls
 //! - **Flexible Storage**: Memory-only or persistent modes with async I/O
 //! - **JSON Patch Support**: RFC 6902 compliant partial updates for JSON values
@@ -280,17 +280,17 @@
 //!
 //! | Operation | Latency (Memory Mode) | Throughput |
 //! |-----------|----------------------|------------|
-//! | GET       | ~200-260ns | 2.1M ops/sec |
-//! | INSERT    | ~700ns | 850K ops/sec |
-//! | DELETE    | ~290ns | 1.1M ops/sec |
-//! | Mixed (80/20) | ~290ns | 3.1M ops/sec |
+//! | GET       | ~180-205ns | 11-14M ops/sec |
+//! | INSERT    | ~630-970ns | 1.0-1.8M ops/sec |
+//! | DELETE    | ~250ns | 4M ops/sec |
+//! | Mixed (80/20) | ~280ns | 3.8M ops/sec |
 //!
 //! ## Architecture Overview
 //!
 //! FeOxDB uses a lock-free, multi-tier architecture optimized for modern multi-core CPUs:
 //!
 //! ### Lock-Free Data Structures
-//! - **Hash Table**: DashMap provides lock-free concurrent hash map with sharded locks
+//! - **Hash Table**: SCC HashMap provides fine-grained locking optimized for high concurrency
 //! - **Ordered Index**: Crossbeam SkipList enables lock-free sorted traversal
 //! - **Atomic Operations**: All metadata updates use atomic primitives in hot path
 //!
@@ -301,7 +301,7 @@
 //! - **Write Coalescing**: Multiple updates to the same key are automatically coalesced
 //!
 //! ### Storage Tiers
-//! 1. **In-Memory Layer**: Hot data in DashMap with O(1) access
+//! 1. **In-Memory Layer**: Hot data in SCC HashMap with O(1) access
 //! 2. **Write Buffer**: Sharded buffers with thread-local affinity for write batching
 //! 3. **Persistent Storage**: Sector-aligned async I/O with write-ahead logging
 //! 4. **Cache Layer**: CLOCK algorithm keeps frequently accessed data in memory

--- a/src/tests/store/operations_tests.rs
+++ b/src/tests/store/operations_tests.rs
@@ -152,3 +152,139 @@ fn test_get_size() {
     // Non-existent key should error
     assert!(store.get_size(b"nonexistent").is_err());
 }
+
+#[test]
+fn test_insert_bytes_basic() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    let key = b"bytes_key";
+    let value = Bytes::from_static(b"test_value");
+
+    // Insert using Bytes
+    store.insert_bytes(key, value.clone()).unwrap();
+
+    // Retrieve and verify
+    let retrieved = store.get(key).unwrap();
+    assert_eq!(retrieved.as_slice(), b"test_value");
+
+    // Also check with get_bytes
+    let bytes_result = store.get_bytes(key).unwrap();
+    assert_eq!(&bytes_result[..], b"test_value");
+}
+
+#[test]
+fn test_insert_bytes_with_timestamp() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    let key = b"timestamped_bytes";
+    let value1 = Bytes::from(vec![1, 2, 3, 4]);
+    let value2 = Bytes::from(vec![5, 6, 7, 8]);
+
+    // Insert with explicit timestamp
+    store
+        .insert_bytes_with_timestamp(key, value1, Some(100))
+        .unwrap();
+
+    // Try to insert with older timestamp - should fail
+    let result = store.insert_bytes_with_timestamp(key, value2.clone(), Some(50));
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), FeoxError::OlderTimestamp));
+
+    // Insert with newer timestamp - should succeed
+    store
+        .insert_bytes_with_timestamp(key, value2.clone(), Some(200))
+        .unwrap();
+
+    let retrieved = store.get(key).unwrap();
+    assert_eq!(retrieved.as_slice(), &[5, 6, 7, 8]);
+}
+
+#[test]
+fn test_insert_bytes_zero_copy() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    // Create a large Bytes value
+    let large_data = vec![42u8; 100_000];
+    let bytes_value = Bytes::from(large_data.clone());
+
+    let key = b"large_bytes_key";
+
+    // Insert using Bytes (should avoid copying the 100KB)
+    store.insert_bytes(key, bytes_value).unwrap();
+
+    // Verify the data
+    let retrieved = store.get_bytes(key).unwrap();
+    assert_eq!(retrieved.len(), 100_000);
+    assert!(retrieved.iter().all(|&b| b == 42));
+}
+
+#[test]
+fn test_insert_bytes_update_existing() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    let key = b"update_bytes";
+
+    // First insert with regular insert
+    store.insert(key, b"initial").unwrap();
+
+    // Update with insert_bytes
+    let new_value = Bytes::from_static(b"updated_with_bytes");
+    store.insert_bytes(key, new_value).unwrap();
+
+    let retrieved = store.get(key).unwrap();
+    assert_eq!(retrieved.as_slice(), b"updated_with_bytes");
+}
+
+#[test]
+fn test_insert_bytes_from_static() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    // Using from_static avoids allocation entirely
+    let static_bytes = Bytes::from_static(b"static string data");
+
+    store.insert_bytes(b"static_key", static_bytes).unwrap();
+
+    let retrieved = store.get(b"static_key").unwrap();
+    assert_eq!(retrieved.as_slice(), b"static string data");
+}
+
+#[test]
+fn test_insert_bytes_empty_value() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    let key = b"empty_bytes";
+    let empty = Bytes::new();
+
+    // Empty values should be rejected, consistent with regular insert
+    let result = store.insert_bytes(key, empty);
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), FeoxError::InvalidValueSize));
+}
+
+#[test]
+fn test_insert_bytes_with_slice() {
+    use bytes::Bytes;
+
+    let store = FeoxStore::new(None).unwrap();
+
+    // Create Bytes from a slice of another Bytes
+    let original = Bytes::from(vec![1, 2, 3, 4, 5]);
+    let slice = original.slice(1..4); // Creates a view [2, 3, 4]
+
+    store.insert_bytes(b"slice_key", slice).unwrap();
+
+    let retrieved = store.get(b"slice_key").unwrap();
+    assert_eq!(retrieved.as_slice(), &[2, 3, 4]);
+}


### PR DESCRIPTION
### Changes
  - **Replaced DashMap with SCC HashMap** across all 11 files for better write path concurrency under high concurrent load
  - **Added zero-copy `insert_bytes` operations** to complement existing `get_bytes` functionality
  - **Optimized cache eviction** by removing redundant checks from hot path - cache already manages its own memory internally

### Performance Impact
  - Reduced write contention under high concurrent load
  - Maintained sub-microsecond latencies for all operations
  - Zero-copy insert path reduces allocations for large values
