### PR TITLE
Change return type of insert functions to Result<bool>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feoxdb"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Mehran Toosi <dev@mehran.dk>"]
 description = "Iron-oxide fast embedded database - nanosecond-level key-value storage"

--- a/src/core/store/internal.rs
+++ b/src/core/store/internal.rs
@@ -18,7 +18,7 @@ impl FeoxStore {
         value: &[u8],
         timestamp: u64,
         ttl_expiry: u64,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let new_record = if ttl_expiry > 0 && self.enable_ttl {
             Arc::new(Record::new_with_timestamp_ttl(
                 old_record.key.clone(),
@@ -84,7 +84,7 @@ impl FeoxStore {
             }
         }
 
-        Ok(())
+        Ok(false)
     }
 
     /// Update an existing record with a new value (Bytes version for zero-copy).
@@ -94,7 +94,7 @@ impl FeoxStore {
         value: Bytes,
         timestamp: u64,
         ttl_expiry: u64,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let new_record = if ttl_expiry > 0 && self.enable_ttl {
             Arc::new(Record::new_from_bytes_with_ttl(
                 old_record.key.clone(),
@@ -160,7 +160,7 @@ impl FeoxStore {
             }
         }
 
-        Ok(())
+        Ok(false)
     }
 
     /// Get access to hash table (for TTL cleaner)

--- a/src/core/store/json_patch.rs
+++ b/src/core/store/json_patch.rs
@@ -95,6 +95,7 @@ impl FeoxStore {
         let new_value = crate::utils::json_patch::apply_json_patch(&current_value, patch)?;
 
         // Now update without holding any references
-        self.insert_with_timestamp(key, &new_value, Some(timestamp))
+        self.insert_with_timestamp(key, &new_value, Some(timestamp))?;
+        Ok(())
     }
 }

--- a/src/core/store/ttl.rs
+++ b/src/core/store/ttl.rs
@@ -37,7 +37,7 @@ impl FeoxStore {
     ///
     /// * Memory mode: ~800ns
     /// * Persistent mode: ~1µs (buffered write)
-    pub fn insert_with_ttl(&self, key: &[u8], value: &[u8], ttl_seconds: u64) -> Result<()> {
+    pub fn insert_with_ttl(&self, key: &[u8], value: &[u8], ttl_seconds: u64) -> Result<bool> {
         if !self.enable_ttl {
             return Err(FeoxError::TtlNotEnabled);
         }
@@ -62,7 +62,7 @@ impl FeoxStore {
         value: &[u8],
         ttl_seconds: u64,
         timestamp: Option<u64>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !self.enable_ttl {
             return Err(FeoxError::TtlNotEnabled);
         }
@@ -114,7 +114,12 @@ impl FeoxStore {
     ///
     /// * Memory mode: ~800ns (avoids value copy)
     /// * Persistent mode: ~1µs (buffered write, avoids value copy)
-    pub fn insert_bytes_with_ttl(&self, key: &[u8], value: Bytes, ttl_seconds: u64) -> Result<()> {
+    pub fn insert_bytes_with_ttl(
+        &self,
+        key: &[u8],
+        value: Bytes,
+        ttl_seconds: u64,
+    ) -> Result<bool> {
         if !self.enable_ttl {
             return Err(FeoxError::TtlNotEnabled);
         }
@@ -139,7 +144,7 @@ impl FeoxStore {
         value: Bytes,
         ttl_seconds: u64,
         timestamp: Option<u64>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !self.enable_ttl {
             return Err(FeoxError::TtlNotEnabled);
         }


### PR DESCRIPTION
change return type of insert functions to Result to indicate if a new key was inserted or an existing key was updated